### PR TITLE
Sequence articles by post date, on index page

### DIFF
--- a/src/blog.site-generator/build-module.psm1
+++ b/src/blog.site-generator/build-module.psm1
@@ -71,7 +71,7 @@ function Get-Articles {
     [CmdletBinding()]
     param()
 
-    return Get-ArticlePaths | Get-Article
+    return Get-ArticlePaths | Get-Article | Sort-Object { $_.MetaData.date }
 }
 Export-ModuleMember -Function Get-Articles
 

--- a/src/blog.template/index.html
+++ b/src/blog.template/index.html
@@ -60,8 +60,8 @@
 
 
     <div class="jumbotron text-center" style=" background-image: url('$(lead-article-image)'); background-size: cover; ">
-        <h1 class="display-4">$(lead-article-title)</h1>
-        <p class="lead">$(lead-article-slug)</p>
+        <h1 class="display-4 text-white" style=" text-shadow: 0 2px 0 black; ">$(lead-article-title)</h1>
+        <p class="lead text-white" style=" text-shadow: 0 2px 0 black; ">$(lead-article-slug)</p>
         <a class="btn btn-primary btn-lg" href="$(lead-article-path)" role="button">read more</a>
     </div>
 


### PR DESCRIPTION
Previously articles were ordered alphabetically.  Thas was nuts.  Now the newest articles are at the top and the oldest is located at the bottom.

Fixes: #17 