### PR TITLE
Automatically tag repo on master merges

### DIFF
--- a/.github/workflows/tag-master-merges.yml
+++ b/.github/workflows/tag-master-merges.yml
@@ -1,0 +1,16 @@
+name: Tag master merge
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Generate Tag
+      run: src/blog.site-generator/tag-release.ps1 -Verbose -BuildNumber $env:GITHUB_RUN_NUMBER
+      shell: pwsh

--- a/src/blog.site-generator/build-module.psm1
+++ b/src/blog.site-generator/build-module.psm1
@@ -10,7 +10,7 @@ Set-StrictMode -Version 'Latest'
 
 
 # Returns the current version number
-# Format: Major.Minor.Patch.Build
+# Format: Major.Minor.Build
 function Get-VersionNumber {
     [CmdletBinding()]
     param(
@@ -22,7 +22,7 @@ function Get-VersionNumber {
     $versionPath = Join-Path -Path $PSScriptRoot -ChildPath '..' 'common' 'version.xml'
     $version = Select-Xml -Path $versionPath -XPath '/version'
 
-    return "$($version.Node.major).$($version.Node.minor).$($version.Node.patch).$($BuildNumber)"
+    return "$($version.Node.major).$($version.Node.minor).$($BuildNumber)"
 }
 Export-ModuleMember -Function 'Get-VersionNumber'
 

--- a/src/blog.site-generator/tag-release.ps1
+++ b/src/blog.site-generator/tag-release.ps1
@@ -1,0 +1,16 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]
+    $BuildNumber
+)
+
+Set-StrictMode -Version 'Latest'
+
+Import-Module ./build-module.psm1 -Force
+
+
+$versionNumber = Get-VersionNumber -BuildNumber $BuildNumber
+
+Write-Verbose "Tagging release with version number $versionNumber"
+git tag -a $versionNumber -m "Release version $versionNumber"

--- a/src/common/version.xml
+++ b/src/common/version.xml
@@ -2,5 +2,4 @@
 <version>
     <major>0</major>
     <minor>1</minor>
-    <patch>0</patch>
 </version>


### PR DESCRIPTION
New workflow added to auto-tag released versions.  A version is considered as a released if/when merged to master.

Fixes: #28 