### PR TITLE
Version number fix

### DIFF
--- a/.github/workflows/azure-static-web-apps-witty-bay-0219c9d03.yml
+++ b/.github/workflows/azure-static-web-apps-witty-bay-0219c9d03.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           dotnet run --project src/blog.generator/blog.generator.csproj `
           -- `
-          --version-number "$(src/common/Get-VersionNumber.ps1 -IncludeSha)" `
+          --version-number "$(scripts/Get-VersionNumber.ps1 -IncludeSha)" `
           --blog-root src/blog `
           --template-root src/blog.template `
           --articles-source-root src/blog.articles `

--- a/.github/workflows/tag-master-merges.yml
+++ b/.github/workflows/tag-master-merges.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Get Version Number
       id: ver
       run: |
-        $version = src/common/Get-VersionNumber.ps1
+        $version = scripts/Get-VersionNumber.ps1
         echo "::set-env name=version_number::$version"
       shell: pwsh
 

--- a/scripts/Get-ReleaseNotes.ps1
+++ b/scripts/Get-ReleaseNotes.ps1
@@ -24,7 +24,8 @@ $rawLog = (git log --pretty=format:"%D%+s%n" | Select-String -Pattern $keyLogEnt
 
 # The log is read into a dictionary, using the the version number as a key
 # This allows us to process and sort the content later
-$currentVersion = 'vNext'
+$currentVersionPath = Join-Path -Path $PSScriptRoot -ChildPath 'Get-VersionNumber.ps1'
+$currentVersion = & $currentVersionPath
 $versionLog = @{}
 $versionLog[$currentVersion] = @()
 

--- a/scripts/Get-VersionNumber.ps1
+++ b/scripts/Get-VersionNumber.ps1
@@ -15,7 +15,7 @@ param(
 
 Set-StrictMode -Version 'Latest'
 
-$versionPath = Join-Path -Path $PSScriptRoot -ChildPath 'version.xml'
+$versionPath = Join-Path -Path $PSScriptRoot -ChildPath '..' 'src' 'common' 'version.xml'
 $versionXml = Select-Xml -Path $versionPath -XPath '/version'
 
 


### PR DESCRIPTION
The release notes grouped the current round of changes under the heading `vNext`.  This has been changed to the current version number.  The process uses the same script that provides the version number to the CD pipeline.