### PR TITLE
Style block quotes

### DIFF
--- a/src/blog.generator/Processors/BlockquoteFormatProcessor.cs
+++ b/src/blog.generator/Processors/BlockquoteFormatProcessor.cs
@@ -1,0 +1,46 @@
+using Blog.Generator.Contexts;
+using Blog.Generator.Processors.Abstractions;
+using HtmlAgilityPack;
+using System;
+using System.Text;
+
+
+namespace Blog.Generator.Processors
+{
+    public class BlockquoteFormatProcessor : MarkupProcessor
+    {
+        public override void Invoke(MarkupContext context)
+        {
+            // Avoid parsing Html if required
+            if(MightContainBlockquotes())
+            {
+                Console.WriteLine($"Formatting blockquotes: {context.Html.Path}");
+
+                var htmlDoc = new HtmlDocument();
+                htmlDoc.LoadHtml(context.Html.Content);
+
+                foreach(var quote in GetBlockquotes(htmlDoc))
+                {
+                    quote.AddClass("alert");
+                    quote.AddClass("alert-primary");
+                    quote.Attributes.Add("role", "alert");
+                }
+
+                context.Html.Content = htmlDoc.DocumentNode.OuterHtml;
+            }
+
+
+            // Simple text check
+            // Can return false positives but not false negatives
+            bool MightContainBlockquotes() => context.Html.Content.Contains("<blockquote");
+
+            HtmlNodeCollection GetBlockquotes(HtmlDocument htmlDoc)
+            {
+                // Markdig converts quotes to: <blockquote><p>**Html-Content-Here**</p></blockquote>
+                return htmlDoc.DocumentNode.SelectNodes("//blockquote/p");
+            }
+        }
+
+        public override string ToString() => "Blockquote Format Processor";
+    }
+}

--- a/src/blog.generator/Processors/ProcessorPipelineBuilderExtensions.cs
+++ b/src/blog.generator/Processors/ProcessorPipelineBuilderExtensions.cs
@@ -54,6 +54,12 @@ namespace Blog.Generator.Processors
             return pipelineBuilder;
         }
 
+        public static ProcessorPipelineBuilder UseBlockQuoteFormatProcessor(this ProcessorPipelineBuilder pipelineBuilder)
+        {
+            pipelineBuilder.RegisterPipelineProcessor(new BlockquoteFormatProcessor());
+            return pipelineBuilder;
+        }
+
         public static ProcessorPipelineBuilder UseSitemapsProcessor(this ProcessorPipelineBuilder pipelineBuilder)
         {
             pipelineBuilder.RegisterPipelineProcessor(new SitemapsProcessor());

--- a/src/blog.generator/Program.cs
+++ b/src/blog.generator/Program.cs
@@ -67,6 +67,7 @@ namespace Blog.Generator
                     .UseInjectMarkdownArticlesProcessor()
                     .UseYamlProcessor()
                     .UseMarkdownProcessor()
+                    .UseBlockQuoteFormatProcessor()
                     .UseArticleNavigationProcessor()
                     .UseArticleSearchProcessor()
                     .UseIndexPageProcessor()


### PR DESCRIPTION
Previously quotes were hard to distinguish from other text.  They are now styled using [bootstrap alerts](https://getbootstrap.com/docs/4.0/components/alerts/).

Fixes #50